### PR TITLE
Fixes inability to sync with beta versions of Anki

### DIFF
--- a/ankisyncd/sync_app.py
+++ b/ankisyncd/sync_app.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import random
+import re
 import string
 import sys
 import time
@@ -63,7 +64,9 @@ class SyncCollectionHandler(anki.sync.Syncer):
                 version = vs[0]
                 note[name] = int(vs[-1])
 
-        version_int = [int(x) for x in version.split('.')]
+        # convert the version string, ignoring non-numeric suffixes like in beta versions of Anki
+        version_nosuffix = re.sub(r'[^0-9.].*$', '', version)
+        version_int = [int(x) for x in version_nosuffix.split('.')]
 
         if client == 'ankidesktop':
             return version_int < [2, 0, 27]


### PR DESCRIPTION
The version string for '2.1.6-beta2' is reported as '2.1.6-' which causes a problem when trying to parse '6-' as an integer.

Example traceback from causing the original issue (sorry, systemd decided to elide it):
```
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/thread.py", line 71, in _run
Dec 10 16:42:33 beluga python3[2487]:     ret = self.wrapper.execute(func, args, kw, return_queue)
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/collection.py", line 39, in execute
Dec 10 16:42:33 beluga python3[2487]:     ret = func(*args, **kw)
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/sync_app.py", line 672, in run_func
Dec 10 16:42:33 beluga python3[2487]:     res = handler_method(**keyword_args)
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/sync_app.py", line 82, in meta
Dec 10 16:42:33 beluga python3[2487]:     if self._old_client(cv):
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/sync_app.py", line 68, in _old_client
Dec 10 16:42:33 beluga python3[2487]:     version_int = [int(x) for x in version.split('.')]
Dec 10 16:42:33 beluga python3[2487]:   File "/home/anki/anki-sync-server/ankisyncd/sync_app.py", line 68, in <listcomp>
Dec 10 16:42:33 beluga python3[2487]:     version_int = [int(x) for x in version.split('.')]
Dec 10 16:42:33 beluga python3[2487]: ValueError: invalid literal for int() with base 10: '6-'
```

Thanks for maintaining this software!