### PR TITLE
Account for potential hostNum sync URLs.

### DIFF
--- a/ankisyncd.conf
+++ b/ankisyncd.conf
@@ -3,8 +3,8 @@
 host = 0.0.0.0
 port = 27701
 data_root = ./collections
-base_url = /sync/
-base_media_url = /msync/
+base_url = /${hostNum}sync/
+base_media_url = /${hostNum}msync/
 auth_db_path = ./auth.db
 # optional, for session persistence between restarts
 session_db_path = ./session.db


### PR DESCRIPTION
Newer Anki desktop versions potentially prepend the sync URL paths with a number (the hostNum of the user).

Should address https://github.com/tsudoko/anki-sync-server/issues/8