### PR TITLE
Isolate persistence managers and add mechanism for loading external classes from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,20 @@ remove every line starting with "pyaudio" in requirements.txt
     $ sed -i '/^pyaudio/d' requirements.txt
 
 ENVVAR configuration overrides
-==============================
+------------------------------
 
 Configuration values can be set via environment variables using `ANKISYNCD_` prepended
 to the uppercase form of the configuration value. E.g. the environment variable,
 `ANKISYNCD_AUTH_DB_PATH` will set the configuration value `auth_db_path`
 
 Environment variables override the values set in the `ankisyncd.conf`.
+
+Support for other database backends
+-----------------------------------
+
+sqlite3 is used by default for user data, authentication and session persistence.
+
+`ankisyncd` supports loading classes defined via config that manage most
+persistence requirements (the media DB and files are being worked on). All that is
+required is to extend one of the existing manager classes and then reference those
+classes in the config file. See ankisyncd.conf for example config.

--- a/ankisyncctl.py
+++ b/ankisyncctl.py
@@ -4,11 +4,10 @@ import sys
 import getpass
 
 import ankisyncd.config
-from ankisyncd.users import SqliteUserManager
+from ankisyncd.users import get_user_manager
+
 
 config = ankisyncd.config.load()
-AUTHDBPATH = config['auth_db_path']
-COLLECTIONPATH = config['data_root']
 
 def usage():
     print("usage: {} <command> [<args>]".format(sys.argv[0]))
@@ -22,18 +21,18 @@ def usage():
 def adduser(username):
     password = getpass.getpass("Enter password for {}: ".format(username))
 
-    user_manager = SqliteUserManager(AUTHDBPATH, COLLECTIONPATH)
+    user_manager = get_user_manager(config)
     user_manager.add_user(username, password)
 
 def deluser(username):
-    user_manager = SqliteUserManager(AUTHDBPATH, COLLECTIONPATH)
+    user_manager = get_user_manager(config)
     try:
         user_manager.del_user(username)
     except ValueError as error:
         print("Could not delete user {}: {}".format(username, error), file=sys.stderr)
 
 def lsuser():
-    user_manager = SqliteUserManager(AUTHDBPATH, COLLECTIONPATH)
+    user_manager = get_user_manager(config)
     try:
         users = user_manager.user_list()
         for username in users:
@@ -42,7 +41,7 @@ def lsuser():
         print("Could not list users: {}".format(error), file=sys.stderr)
 
 def passwd(username):
-    user_manager = SqliteUserManager(AUTHDBPATH, COLLECTIONPATH)
+    user_manager = get_user_manager(config)
 
     if username not in user_manager.user_list():
         print("User {} doesn't exist".format(username))

--- a/ankisyncd.conf
+++ b/ankisyncd.conf
@@ -8,3 +8,13 @@ base_media_url = /msync/
 auth_db_path = ./auth.db
 # optional, for session persistence between restarts
 session_db_path = ./session.db
+
+# optional, for overriding the default managers and wrappers
+# # must inherit from ankisyncd.persistence.PersistenceManger, e.g,
+# persistence_manager = great_stuff.postgres.PostgresPersistenceManager
+# # must inherit from ankisyncd.session.SimpleSessionManager, e.g,
+# session_manager = great_stuff.postgres.PostgresSessionManager
+# # must inherit from ankisyncd.user.SimpleUserManager, e.g,
+# user_manager = great_stuff.postgres.PostgresUserManager
+# # must inherit from ankisyncd.collections.CollectionWrapper, e.g,
+# collection_wrapper = great_stuff.postgres.PostgresCollectionWrapper

--- a/ankisyncd/full_sync.py
+++ b/ankisyncd/full_sync.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+import os
+from sqlite3 import dbapi2 as sqlite
+
+import anki.db
+
+class FullSyncManager:
+    def upload(self, col, data, session):
+        # Verify integrity of the received database file before replacing our
+        # existing db.
+        temp_db_path = session.get_collection_path() + ".tmp"
+        with open(temp_db_path, 'wb') as f:
+            f.write(data)
+
+        try:
+            with anki.db.DB(temp_db_path) as test_db:
+                if test_db.scalar("pragma integrity_check") != "ok":
+                    raise HTTPBadRequest("Integrity check failed for uploaded "
+                                         "collection database file.")
+        except sqlite.Error as e:
+            raise HTTPBadRequest("Uploaded collection database file is "
+                                 "corrupt.")
+
+        # Overwrite existing db.
+        col.close()
+        try:
+            os.rename(temp_db_path, session.get_collection_path())
+        finally:
+            col.reopen()
+            col.load()
+
+        return "OK"
+
+
+    def download(self, col, session):
+        col.close()
+        try:
+            data = open(session.get_collection_path(), 'rb').read()
+        finally:
+            col.reopen()
+            col.load()
+        return data
+
+
+def get_full_sync_manager(config):
+    if "full_sync_manager" in config and config["full_sync_manager"]:  # load from config
+        import importlib
+        import inspect
+        module_name, class_name = config['full_sync_manager'].rsplit('.', 1)
+        module = importlib.import_module(module_name.strip())
+        class_ = getattr(module, class_name.strip())
+
+        if not FullSyncManager in inspect.getmro(class_):
+            raise TypeError('''"full_sync_manager" found in the conf file but it doesn''t
+                            inherit from FullSyncManager''')
+        return class_(config)
+    else:
+        return FullSyncManager()

--- a/ankisyncd/sessions.py
+++ b/ankisyncd/sessions.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import os
+import logging
+from sqlite3 import dbapi2 as sqlite
+
+logger = logging.getLogger("ankisyncd.sessions")
+
+
+class SimpleSessionManager:
+    """A simple session manager that keeps the sessions in memory."""
+
+    def __init__(self):
+        self.sessions = {}
+
+    def load(self, hkey, session_factory=None):
+        return self.sessions.get(hkey)
+
+    def load_from_skey(self, skey, session_factory=None):
+        for i in self.sessions:
+            if self.sessions[i].skey == skey:
+                return self.sessions[i]
+
+    def save(self, hkey, session):
+        self.sessions[hkey] = session
+
+    def delete(self, hkey):
+        del self.sessions[hkey]
+
+
+class SqliteSessionManager(SimpleSessionManager):
+    """Stores sessions in a SQLite database to prevent the user from being logged out
+    everytime the SyncApp is restarted."""
+
+    def __init__(self, session_db_path):
+        SimpleSessionManager.__init__(self)
+
+        self.session_db_path = os.path.realpath(session_db_path)
+
+    def _conn(self):
+        new = not os.path.exists(self.session_db_path)
+        conn = sqlite.connect(self.session_db_path)
+        if new:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE session (hkey VARCHAR PRIMARY KEY, skey VARCHAR, username VARCHAR, path VARCHAR)")
+        return conn
+
+    # Default to using sqlite3 syntax but overridable for sub-classes using other
+    # DB API 2 driver variants
+    @staticmethod
+    def fs(sql):
+        return sql
+
+    def load(self, hkey, session_factory=None):
+        session = SimpleSessionManager.load(self, hkey)
+        if session is not None:
+            return session
+
+        conn = self._conn()
+        cursor = conn.cursor()
+
+        cursor.execute(self.fs("SELECT skey, username, path FROM session WHERE hkey=?"), (hkey,))
+        res = cursor.fetchone()
+
+        if res is not None:
+            session = self.sessions[hkey] = session_factory(res[1], res[2])
+            session.skey = res[0]
+            return session
+
+    def load_from_skey(self, skey, session_factory=None):
+        session = SimpleSessionManager.load_from_skey(self, skey)
+        if session is not None:
+            return session
+
+        conn = self._conn()
+        cursor = conn.cursor()
+
+        cursor.execute(self.fs("SELECT hkey, username, path FROM session WHERE skey=?"), (skey,))
+        res = cursor.fetchone()
+
+        if res is not None:
+            session = self.sessions[res[0]] = session_factory(res[1], res[2])
+            session.skey = skey
+            return session
+
+    def save(self, hkey, session):
+        SimpleSessionManager.save(self, hkey, session)
+
+        conn = self._conn()
+        cursor = conn.cursor()
+
+        cursor.execute("INSERT OR REPLACE INTO session (hkey, skey, username, path) VALUES (?, ?, ?, ?)",
+            (hkey, session.skey, session.name, session.path))
+
+        conn.commit()
+
+    def delete(self, hkey):
+        SimpleSessionManager.delete(self, hkey)
+
+        conn = self._conn()
+        cursor = conn.cursor()
+
+        cursor.execute(self.fs("DELETE FROM session WHERE hkey=?"), (hkey,))
+        conn.commit()
+
+def get_session_manager(config):
+    if "session_db_path" in config and config["session_db_path"]:
+        logger.info("Found session_db_path in config, using SqliteSessionManager for auth")
+        return SqliteSessionManager(config['session_db_path'])
+    elif "session_manager" in config and config["session_manager"]:  # load from config
+        logger.info("Found session_manager in config, using {} for persisting sessions".format(
+            config['session_manager'])
+        )
+        import importlib
+        import inspect
+        module_name, class_name = config['session_manager'].rsplit('.', 1)
+        module = importlib.import_module(module_name.strip())
+        class_ = getattr(module, class_name.strip())
+
+        if not SimpleSessionManager in inspect.getmro(class_):
+            raise TypeError('''"session_manager" found in the conf file but it doesn''t
+                            inherit from SimpleSessionManager''')
+        return class_(config)
+    else:
+        logger.warning("Neither session_db_path nor session_manager set, "
+                     "ankisyncd will lose sessions on application restart")
+        return SimpleSessionManager()

--- a/ankisyncd/sync_app.py
+++ b/ankisyncd/sync_app.py
@@ -40,7 +40,7 @@ import anki.utils
 from anki.consts import SYNC_VER, SYNC_ZIP_SIZE, SYNC_ZIP_COUNT
 from anki.consts import REM_CARD, REM_NOTE
 
-from ankisyncd.users import SimpleUserManager, SqliteUserManager
+from ankisyncd.users import get_user_manager
 
 logger = logging.getLogger("ankisyncd")
 
@@ -421,12 +421,7 @@ class SyncApp:
         else:
             self.session_manager = SimpleSessionManager()
 
-        if "auth_db_path" in config:
-            self.user_manager = SqliteUserManager(config['auth_db_path'])
-        else:
-            logger.warn("auth_db_path not set, ankisyncd will accept any password")
-            self.user_manager = SimpleUserManager()
-
+        self.user_manager = get_user_manager(config)
         self.collection_manager = getCollectionManager()
 
         # make sure the base_url has a trailing slash

--- a/ankisyncd/sync_app.py
+++ b/ankisyncd/sync_app.py
@@ -388,7 +388,7 @@ class SyncApp:
     valid_urls = SyncCollectionHandler.operations + SyncMediaHandler.operations + ['hostKey', 'upload', 'download']
 
     def __init__(self, config):
-        from ankisyncd.thread import getCollectionManager
+        from ankisyncd.thread import get_collection_manager
 
         self.data_root = os.path.abspath(config['data_root'])
         self.base_url  = config['base_url']
@@ -401,7 +401,7 @@ class SyncApp:
         self.user_manager = get_user_manager(config)
         self.session_manager = get_session_manager(config)
         self.full_sync_manager = get_full_sync_manager(config)
-        self.collection_manager = getCollectionManager()
+        self.collection_manager = get_collection_manager(config)
 
         # make sure the base_url has a trailing slash
         if not self.base_url.endswith('/'):

--- a/ankisyncd/thread.py
+++ b/ankisyncd/thread.py
@@ -1,4 +1,4 @@
-from ankisyncd.collection import CollectionWrapper, CollectionManager
+from ankisyncd.collection import CollectionManager, get_collection_wrapper
 
 from threading import Thread
 from queue import Queue
@@ -29,12 +29,12 @@ def short_repr(obj, logger=logging.getLogger(), maxlen=80):
     return repr(o)
 
 class ThreadingCollectionWrapper:
-    """Provides the same interface as CollectionWrapper, but it creates a new Thread to 
+    """Provides the same interface as CollectionWrapper, but it creates a new Thread to
     interact with the collection."""
 
-    def __init__(self, path, setup_new_collection=None):
+    def __init__(self, config, path, setup_new_collection=None):
         self.path = path
-        self.wrapper = CollectionWrapper(path, setup_new_collection)
+        self.wrapper = get_collection_wrapper(config, path, setup_new_collection)
         self.logger = logging.getLogger("ankisyncd." + str(self))
 
         self._queue = Queue()
@@ -156,8 +156,8 @@ class ThreadingCollectionManager(CollectionManager):
 
     collection_wrapper = ThreadingCollectionWrapper
 
-    def __init__(self):
-        super(ThreadingCollectionManager, self).__init__()
+    def __init__(self, config):
+        super(ThreadingCollectionManager, self).__init__(config)
 
         self.monitor_frequency = 15
         self.monitor_inactivity = 90
@@ -202,11 +202,11 @@ class ThreadingCollectionManager(CollectionManager):
 
 collection_manager = None
 
-def getCollectionManager():
+def get_collection_manager(config):
     """Return the global ThreadingCollectionManager for this process."""
     global collection_manager
     if collection_manager is None:
-        collection_manager = ThreadingCollectionManager()
+        collection_manager = ThreadingCollectionManager(config)
     return collection_manager
 
 def shutdown():

--- a/tests/test_collection_wrappers.py
+++ b/tests/test_collection_wrappers.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+import configparser
+
+from ankisyncd.collection import CollectionWrapper
+from ankisyncd.collection import get_collection_wrapper
+
+import helpers.server_utils
+
+class FakeCollectionWrapper(CollectionWrapper):
+    def __init__(self, config, path, setup_new_collection=None):
+        self. _CollectionWrapper__col = None
+        pass
+
+class BadCollectionWrapper:
+    pass
+
+class CollectionWrapperFactoryTest(unittest.TestCase):
+    def test_get_collection_wrapper(self):
+        # Get absolute path to development ini file.
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        ini_file_path = os.path.join(script_dir,
+                                     "assets",
+                                     "test.conf")
+
+        # Create temporary files and dirs the server will use.
+        server_paths = helpers.server_utils.create_server_paths()
+
+        config = configparser.ConfigParser()
+        config.read(ini_file_path)
+        path = os.path.realpath('fake/collection.anki2')
+
+        # Use custom files and dirs in settings. Should be CollectionWrapper
+        config['sync_app'].update(server_paths)
+        self.assertTrue(type(get_collection_wrapper(config['sync_app'], path) == CollectionWrapper))
+
+        # A conf-specified CollectionWrapper is loaded
+        config.set("sync_app", "collection_wrapper", 'test_collection_wrappers.FakeCollectionWrapper')
+        self.assertTrue(type(get_collection_wrapper(config['sync_app'], path)) == FakeCollectionWrapper)
+
+        # Should fail at load time if the class doesn't inherit from CollectionWrapper
+        config.set("sync_app", "collection_wrapper", 'test_collection_wrappers.BadCollectionWrapper')
+        with self.assertRaises(TypeError):
+            pm = get_collection_wrapper(config['sync_app'], path)
+

--- a/tests/test_full_sync.py
+++ b/tests/test_full_sync.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+import configparser
+
+from ankisyncd.full_sync import FullSyncManager, get_full_sync_manager
+
+import helpers.server_utils
+
+class FakeFullSyncManager(FullSyncManager):
+    def __init__(self, config):
+        pass
+
+class BadFullSyncManager:
+    pass
+
+class FullSyncManagerFactoryTest(unittest.TestCase):
+    def test_get_full_sync_manager(self):
+        # Get absolute path to development ini file.
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        ini_file_path = os.path.join(script_dir,
+                                     "assets",
+                                     "test.conf")
+
+        # Create temporary files and dirs the server will use.
+        server_paths = helpers.server_utils.create_server_paths()
+
+        config = configparser.ConfigParser()
+        config.read(ini_file_path)
+
+        # Use custom files and dirs in settings. Should be PersistenceManager
+        config['sync_app'].update(server_paths)
+        self.assertTrue(type(get_full_sync_manager(config['sync_app']) == FullSyncManager))
+
+        # A conf-specified FullSyncManager is loaded
+        config.set("sync_app", "full_sync_manager", 'test_full_sync.FakeFullSyncManager')
+        self.assertTrue(type(get_full_sync_manager(config['sync_app'])) == FakeFullSyncManager)
+
+        # Should fail at load time if the class doesn't inherit from FullSyncManager
+        config.set("sync_app", "full_sync_manager", 'test_full_sync.BadFullSyncManager')
+        with self.assertRaises(TypeError):
+            pm = get_full_sync_manager(config['sync_app'])
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+import sqlite3
+import unittest
+import configparser
+
+from ankisyncd.sessions import SimpleSessionManager
+from ankisyncd.sessions import SqliteSessionManager
+from ankisyncd.sessions import get_session_manager
+
+from ankisyncd.sync_app import SyncUserSession
+
+import helpers.server_utils
+
+class FakeSessionManager(SimpleSessionManager):
+    def __init__(self, config):
+        pass
+
+class BadSessionManager:
+    pass
+
+class SessionManagerFactoryTest(unittest.TestCase):
+    def test_get_session_manager(self):
+        # Get absolute path to development ini file.
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        ini_file_path = os.path.join(script_dir,
+                                     "assets",
+                                     "test.conf")
+
+        # Create temporary files and dirs the server will use.
+        server_paths = helpers.server_utils.create_server_paths()
+
+        config = configparser.ConfigParser()
+        config.read(ini_file_path)
+
+        # Use custom files and dirs in settings. Should be SqliteSessionManager
+        config['sync_app'].update(server_paths)
+        self.assertTrue(type(get_session_manager(config['sync_app']) == SqliteSessionManager))
+
+        # No value defaults to SimpleSessionManager
+        config.remove_option("sync_app", "session_db_path")
+        self.assertTrue(type(get_session_manager(config['sync_app'])) == SimpleSessionManager)
+
+        # A conf-specified SessionManager is loaded
+        config.set("sync_app", "session_manager", 'test_sessions.FakeSessionManager')
+        self.assertTrue(type(get_session_manager(config['sync_app'])) == FakeSessionManager)
+
+        # Should fail at load time if the class doesn't inherit from  SimpleSessionManager
+        config.set("sync_app", "session_manager", 'test_sessions.BadSessionManager')
+        with self.assertRaises(TypeError):
+            sm = get_session_manager(config['sync_app'])
+
+        # Add the session_db_path back, it should take precedence over BadSessionManager
+        config['sync_app'].update(server_paths)
+        self.assertTrue(type(get_session_manager(config['sync_app'])) == SqliteSessionManager)
+
+
+class SimpleSessionManagerTest(unittest.TestCase):
+    test_hkey = '1234567890'
+    sdir = tempfile.mkdtemp(suffix="_session")
+    os.rmdir(sdir)
+    test_session = SyncUserSession('testName', sdir, None, None)
+
+    def setUp(self):
+        self.sessionManager = SimpleSessionManager()
+
+    def tearDown(self):
+        self.sessionManager = None
+
+    def test_save(self):
+        self.sessionManager.save(self.test_hkey, self.test_session)
+        self.assertEqual(self.sessionManager.sessions[self.test_hkey].name,
+                         self.test_session.name)
+        self.assertEqual(self.sessionManager.sessions[self.test_hkey].path,
+                         self.test_session.path)
+
+    def test_delete(self):
+        self.sessionManager.save(self.test_hkey, self.test_session)
+        self.assertTrue(self.test_hkey in self.sessionManager.sessions)
+
+        self.sessionManager.delete(self.test_hkey)
+
+        self.assertTrue(self.test_hkey not in self.sessionManager.sessions)
+
+    def test_load(self):
+        self.sessionManager.save(self.test_hkey, self.test_session)
+        self.assertTrue(self.test_hkey in self.sessionManager.sessions)
+
+        loaded_session = self.sessionManager.load(self.test_hkey)
+        self.assertEqual(loaded_session.name, self.test_session.name)
+        self.assertEqual(loaded_session.path, self.test_session.path)
+
+
+class SqliteSessionManagerTest(SimpleSessionManagerTest):
+    file_descriptor, _test_sess_db_path = tempfile.mkstemp(suffix=".db")
+    os.close(file_descriptor)
+    os.unlink(_test_sess_db_path)
+
+    def setUp(self):
+        self.sessionManager = SqliteSessionManager(self._test_sess_db_path)
+
+    def tearDown(self):
+        if os.path.exists(self._test_sess_db_path):
+            os.remove(self._test_sess_db_path)
+
+    def test_save(self):
+        SimpleSessionManagerTest.test_save(self)
+        self.assertTrue(os.path.exists(self._test_sess_db_path))
+
+        conn = sqlite3.connect(self._test_sess_db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT username, path FROM session WHERE hkey=?",
+                       (self.test_hkey,))
+        res = cursor.fetchone()
+        conn.close()
+
+        self.assertEqual(res[0], self.test_session.name)
+        self.assertEqual(res[1], self.test_session.path)
+
+
+

--- a/utils/migrate_user_tables.py
+++ b/utils/migrate_user_tables.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+This script updates the auth and session sqlite3 databases to use the
+more compatible `username` column instead of `user`, which is a reserved
+word in many other SQL dialects.
+"""
+import os
+import sys
+path = os.path.realpath(os.path.abspath(os.path.join(__file__, '../')))
+sys.path.insert(0, os.path.dirname(path))
+
+import sqlite3
+import ankisyncd.config
+conf = ankisyncd.config.load()
+
+
+def main():
+
+    if os.path.isfile(conf["auth_db_path"]):
+        conn = sqlite3.connect(conf["auth_db_path"])
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM sqlite_master "
+                             "WHERE sql LIKE '%user VARCHAR PRIMARY KEY%' "
+                             "AND tbl_name = 'auth'")
+        res = cursor.fetchone()
+
+        if res is not None:
+            cursor.execute("ALTER TABLE auth RENAME TO auth_old")
+            cursor.execute("CREATE TABLE auth (username VARCHAR PRIMARY KEY, hash VARCHAR)")
+            cursor.execute("INSERT INTO auth (username, hash) SELECT user, hash FROM auth_old")
+            cursor.execute("DROP TABLE auth_old")
+            conn.commit()
+            print("Successfully updated table 'auth'")
+        else:
+            print("No outdated 'auth' table found.")
+
+        conn.close()
+    else:
+        print("No auth DB found at the configured 'auth_db_path' path.")
+
+    if os.path.isfile(conf["session_db_path"]):
+        conn = sqlite3.connect(conf["session_db_path"])
+
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM sqlite_master "
+                             "WHERE sql LIKE '%user VARCHAR%' "
+                             "AND tbl_name = 'session'")
+        res = cursor.fetchone()
+
+        if res is not None:
+            cursor.execute("ALTER TABLE session RENAME TO session_old")
+            cursor.execute("CREATE TABLE session (hkey VARCHAR PRIMARY KEY, skey VARCHAR, "
+                           "username VARCHAR, path VARCHAR)")
+            cursor.execute("INSERT INTO session (hkey, skey, username, path) "
+                           "SELECT hkey, skey, user, path FROM session_old")
+            cursor.execute("DROP TABLE session_old")
+            conn.commit()
+            print("Successfully updated table 'session'")
+        else:
+            print("No outdated 'session' table found.")
+
+        conn.close()
+    else:
+        print("No session DB found at the configured 'session_db_path' path.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here is my attempt at https://github.com/tsudoko/anki-sync-server/issues/12. I have a working postgres compatibility layer on top of this. I need an Anki-compatible server for the project at the core of the PhD I'm about to start, so will be able to help out making sure that we keep great compatibility with Anki. That's a 4-year commitment to support this code :-).